### PR TITLE
[codex] Fix loading spinner and add calendar filters

### DIFF
--- a/apps/apple/HotCrossBuns.xcodeproj/project.pbxproj
+++ b/apps/apple/HotCrossBuns.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		46D517DF3CCDC62A677E30B0 /* StoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B73A839AA07E6C98129ED4BB /* StoreView.swift */; };
 		486292178C2C7163A0C8C45E /* QueryDSLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E10912879943FB239566EB /* QueryDSLTests.swift */; };
 		4A0CC79BFC861B5D27E9F288 /* AppCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 838CDC9397AEB8B081E732EE /* AppCommands.swift */; };
+		4BDF6FC9B42F0DADB8E9D6EE /* CalendarViewFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408409D2AEF133FA67392454 /* CalendarViewFilterTests.swift */; };
 		4D00CE67951243CCE90386B4 /* QuickAddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB427444279DD0F8E4B2281 /* QuickAddView.swift */; };
 		4E8052E74A055E77BC2698D9 /* TodayPrintView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C43EE423C47E35EC405972E /* TodayPrintView.swift */; };
 		4EBE176BAF2495405965A5F4 /* GlobalHotkeySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C278E1866E172AB8336C2125 /* GlobalHotkeySection.swift */; };
@@ -92,6 +93,7 @@
 		5C9E280691B2F3198FF32835 /* SmartListFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18883C2377F57F108328C03 /* SmartListFilter.swift */; };
 		5F3A7AC605BABA4F8AA15034 /* DisconnectImpactSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D8817EA22134F837C416DC /* DisconnectImpactSummary.swift */; };
 		61E276C2555F3F36F976E697 /* DiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDBE097FFF4A48F2BCDE315 /* DiagnosticsView.swift */; };
+		62D9B18EA384C519A73569BB /* CalendarViewFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445055F956E8870F1B8DC2E9 /* CalendarViewFilter.swift */; };
 		63F95290D2E706E05C1A9029 /* LocationFullView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEF77C927632A04783BF515 /* LocationFullView.swift */; };
 		64E4A1BA0CF04097F8D1C9CB /* GoToDateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EE90AE73008CDCBB548450 /* GoToDateSheet.swift */; };
 		6781A77091B43C2BBAAEC36A /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 8630D5999C10C8D0FF9DB5A1 /* GoogleSignInSwift */; };
@@ -117,6 +119,7 @@
 		7D80AADD28F287E415B0ED05 /* MonthGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0854A71DD603264D078FB733 /* MonthGridView.swift */; };
 		7F105DF2722D09956A81291D /* BackoffPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0A69B82085B489B5F595CF /* BackoffPolicy.swift */; };
 		804FDD2DCFA8CC6E75971B58 /* TaskHierarchy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD404C87FD0BC2462B844C8C /* TaskHierarchy.swift */; };
+		8073C74A0AEB09575312E1EC /* CalendarSidebarFilters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D90E0806AAFD43B7149E2A3 /* CalendarSidebarFilters.swift */; };
 		81A1C2AB5441CE9439ED0268 /* HCBChordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C7F2CE45DD479F7574C012 /* HCBChordTests.swift */; };
 		823DFA52ED02235FC5C1F640 /* SmartListFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AF38F4F743ECB0079BDD30 /* SmartListFilterTests.swift */; };
 		827C84F1E10F6B534F590F1B /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377A972E3BD6867D3483B92D /* OnboardingView.swift */; };
@@ -335,6 +338,8 @@
 		3B56113BE89523BF7D0AE8EA /* CalendarMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMirror.swift; sourceTree = "<group>"; };
 		3C43EE423C47E35EC405972E /* TodayPrintView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayPrintView.swift; sourceTree = "<group>"; };
 		3FB991136E6E925A2EF0030D /* GuestsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestsSection.swift; sourceTree = "<group>"; };
+		408409D2AEF133FA67392454 /* CalendarViewFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewFilterTests.swift; sourceTree = "<group>"; };
+		445055F956E8870F1B8DC2E9 /* CalendarViewFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewFilter.swift; sourceTree = "<group>"; };
 		44E4CDC1A1234A242228D7CD /* HCBCacheCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HCBCacheCrypto.swift; sourceTree = "<group>"; };
 		451F7A551BAF39DA361383F4 /* NaturalLanguageTaskParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturalLanguageTaskParser.swift; sourceTree = "<group>"; };
 		45D846EE7A564ED968072B3E /* ConversionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversionSheet.swift; sourceTree = "<group>"; };
@@ -358,6 +363,7 @@
 		5959B85AC017728D7F460355 /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		5A2BE751C144C19479D45966 /* AppVersionSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionSection.swift; sourceTree = "<group>"; };
 		5CDBE097FFF4A48F2BCDE315 /* DiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsView.swift; sourceTree = "<group>"; };
+		5D90E0806AAFD43B7149E2A3 /* CalendarSidebarFilters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSidebarFilters.swift; sourceTree = "<group>"; };
 		5DBBBAB47C6578BBCC5A1170 /* MarkdownHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownHighlighter.swift; sourceTree = "<group>"; };
 		5E7CCAAA53D6C1875F338A5B /* CalendarGridLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarGridLayoutTests.swift; sourceTree = "<group>"; };
 		5EEFF7D128C1CEAC536841BF /* CommandPalettePanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPalettePanelController.swift; sourceTree = "<group>"; };
@@ -848,6 +854,7 @@
 				1AE4271884E414A0922884E1 /* CalendarDropComputerTests.swift */,
 				22DB41A975AB784A9EBDD654 /* CalendarEventInstanceTests.swift */,
 				5E7CCAAA53D6C1875F338A5B /* CalendarGridLayoutTests.swift */,
+				408409D2AEF133FA67392454 /* CalendarViewFilterTests.swift */,
 				93E688E332EB1AD0516754E4 /* CloudSyncControlTests.swift */,
 				A59BC37092CD2A812114D355 /* ConversionMapperTests.swift */,
 				F8744975197402E661FA13A2 /* CustomFilterTests.swift */,
@@ -1050,6 +1057,8 @@
 				09D526E7EC054A5BAA2ED4E3 /* CalendarDropComputer.swift */,
 				382C796971460006AB7D939E /* CalendarGridLayout.swift */,
 				F2263C896865029DCEC3A53B /* CalendarHomeView.swift */,
+				5D90E0806AAFD43B7149E2A3 /* CalendarSidebarFilters.swift */,
+				445055F956E8870F1B8DC2E9 /* CalendarViewFilter.swift */,
 				C7927086C6D7ED52806C839E /* DayAgendaPopover.swift */,
 				5219CCB9C481FFD04A218A66 /* DayGridView.swift */,
 				1D137D2E12066C5E9B77CEDA /* EventBulkActionBar.swift */,
@@ -1327,6 +1336,8 @@
 				E97AE973C28C215FBD434B5A /* CalendarGridLayout.swift in Sources */,
 				523A574D6D48B12B4587E086 /* CalendarHomeView.swift in Sources */,
 				06BEC9D87D21345A636AADB8 /* CalendarMirror.swift in Sources */,
+				8073C74A0AEB09575312E1EC /* CalendarSidebarFilters.swift in Sources */,
+				62D9B18EA384C519A73569BB /* CalendarViewFilter.swift in Sources */,
 				B29B39B1BF859B1A2DA630CC /* ChordHUD.swift in Sources */,
 				423A2928A33D4C5387CC339B /* ColorSchemes.swift in Sources */,
 				AAFBB17984DC3CD66994302E /* ColorTagBindingsSection.swift in Sources */,
@@ -1499,6 +1510,7 @@
 				CCFA60589BEC192C6B812D39 /* CalendarDropComputerTests.swift in Sources */,
 				F37DF95BBEC2335CA5AFBDED /* CalendarEventInstanceTests.swift in Sources */,
 				0C684E4902EA8C1B8C94322E /* CalendarGridLayoutTests.swift in Sources */,
+				4BDF6FC9B42F0DADB8E9D6EE /* CalendarViewFilterTests.swift in Sources */,
 				40E3593FBA77960BA94511CF /* CloudSyncControlTests.swift in Sources */,
 				FE216A2BBE372EE6C0DD54FD /* ConversionMapperTests.swift in Sources */,
 				E98AEB930CC53067A2C2BCE3 /* CustomFilterTests.swift in Sources */,

--- a/apps/apple/HotCrossBuns/App/MacSidebarShell.swift
+++ b/apps/apple/HotCrossBuns/App/MacSidebarShell.swift
@@ -125,6 +125,7 @@ struct MacSidebarShell: View {
     @Environment(\.openWindow) private var openWindow
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @SceneStorage("sidebarSelection") private var storedSelection: String = SidebarItem.calendar.rawValue
+    @AppStorage(CalendarViewFilterState.storageKey) private var storedCalendarViewFilters: String = ""
 
     private let layoutScaleMin: Double = 0.80
     private let layoutScaleMax: Double = 1.50
@@ -515,6 +516,11 @@ struct MacSidebarShell: View {
             List(selection: sidebarSelectionBinding) {
                 ForEach(visibleSidebarItems) { item in
                     sidebarRow(for: item)
+                    if item == .calendar, selection == .calendar, model.account != nil {
+                        CalendarSidebarFilters(state: calendarViewFilterStateBinding)
+                            .listRowInsets(EdgeInsets(top: 0, leading: 18, bottom: 6, trailing: 12))
+                            .listRowSeparator(.hidden)
+                    }
                 }
             }
             .listStyle(.sidebar)
@@ -562,10 +568,25 @@ struct MacSidebarShell: View {
             // The outer .environment calls below are belt-and-braces for
             // sheets/inspectors hoisted out of the NavigationStack.
             selection.makeContentView(router: router)
+                .environment(\.calendarEventViewFilter, calendarEventViewFilter)
                 .withAppDestinations()
         }
         .environment(\.routerPath, router)
         .withSheetDestinations(router: router)
+    }
+
+    private var calendarViewFilterStateBinding: Binding<CalendarViewFilterState> {
+        Binding(
+            get: { CalendarViewFilterState.decoded(from: storedCalendarViewFilters) },
+            set: { storedCalendarViewFilters = $0.encodedString() }
+        )
+    }
+
+    private var calendarEventViewFilter: CalendarEventViewFilter {
+        CalendarEventViewFilter(
+            state: CalendarViewFilterState.decoded(from: storedCalendarViewFilters),
+            colorTagBindings: model.settings.colorTagBindings
+        )
     }
 
     private var sidebarSelectionBinding: Binding<SidebarItem?> {

--- a/apps/apple/HotCrossBuns/Design/LoadingView.swift
+++ b/apps/apple/HotCrossBuns/Design/LoadingView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
+import AppKit
+import QuartzCore
 
 struct LoadingView: View {
     let message: String
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var isAnimating = false
 
     var body: some View {
         ZStack {
@@ -12,16 +13,7 @@ struct LoadingView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: 16) {
-                Image("LoadingBunsWelcome")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 104, height: 104)
-                    .rotationEffect(reduceMotion ? .zero : .degrees(isAnimating ? 360 : 0))
-                    .animation(
-                        reduceMotion ? nil : .linear(duration: 1.25).repeatForever(autoreverses: false),
-                        value: isAnimating
-                    )
-                    .accessibilityHidden(true)
+                LoadingBunsIcon(reduceMotion: reduceMotion)
 
                 Text(message)
                     .hcbFont(.headline)
@@ -30,7 +22,114 @@ struct LoadingView: View {
             }
             .padding(28)
         }
-        .onAppear { isAnimating = true }
+    }
+}
+
+private struct LoadingBunsIcon: View {
+    let reduceMotion: Bool
+
+    var body: some View {
+        Group {
+            if reduceMotion {
+                Image("LoadingBunsWelcome")
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                CoreAnimationLoadingBunsIcon()
+            }
+        }
+        .frame(width: 104, height: 104)
+        .accessibilityHidden(true)
+    }
+}
+
+private struct CoreAnimationLoadingBunsIcon: NSViewRepresentable {
+    func makeNSView(context: Context) -> RotatingLoadingBunsView {
+        let view = RotatingLoadingBunsView()
+        view.startAnimating()
+        return view
+    }
+
+    func updateNSView(_ nsView: RotatingLoadingBunsView, context: Context) {
+        nsView.startAnimating()
+    }
+
+    static func dismantleNSView(_ nsView: RotatingLoadingBunsView, coordinator: ()) {
+        nsView.stopAnimating()
+    }
+}
+
+private final class RotatingLoadingBunsView: NSView {
+    private static let animationKey = "hcb.loadingBuns.rotation"
+    private let imageLayer = CALayer()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        setAccessibilityElement(false)
+        imageLayer.contentsGravity = .resizeAspect
+        imageLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        imageLayer.contents = Self.loadingImage()
+        layer?.addSublayer(imageLayer)
+        updateContentsScale()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: 104, height: 104)
+    }
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        let side = min(bounds.width, bounds.height)
+        imageLayer.bounds = CGRect(x: 0, y: 0, width: side, height: side)
+        imageLayer.position = CGPoint(x: bounds.midX, y: bounds.midY)
+        CATransaction.commit()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        updateContentsScale()
+        if window == nil {
+            stopAnimating()
+        } else {
+            startAnimating()
+        }
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        updateContentsScale()
+    }
+
+    func startAnimating() {
+        guard imageLayer.animation(forKey: Self.animationKey) == nil else { return }
+        let animation = CABasicAnimation(keyPath: "transform.rotation.z")
+        animation.fromValue = 0
+        animation.toValue = CGFloat.pi * 2
+        animation.duration = 1.25
+        animation.repeatCount = .infinity
+        animation.timingFunction = CAMediaTimingFunction(name: .linear)
+        animation.isRemovedOnCompletion = false
+        imageLayer.add(animation, forKey: Self.animationKey)
+    }
+
+    func stopAnimating() {
+        imageLayer.removeAnimation(forKey: Self.animationKey)
+    }
+
+    private func updateContentsScale() {
+        imageLayer.contentsScale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
+    }
+
+    private static func loadingImage() -> CGImage? {
+        NSImage(named: "LoadingBunsWelcome")?.cgImage(forProposedRect: nil, context: nil, hints: nil)
     }
 }
 

--- a/apps/apple/HotCrossBuns/Features/Calendar/CalendarHomeView.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/CalendarHomeView.swift
@@ -8,6 +8,7 @@ struct CalendarHomeView: View {
     @Environment(NetworkMonitor.self) private var networkMonitor
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.hcbAppBackgroundConfiguration) private var backgroundConfiguration
+    @Environment(\.calendarEventViewFilter) private var calendarEventViewFilter
     @State private var selectedDate = Date()
     @SceneStorage("calendarGridMode") private var storedMode: String = CalendarGridMode.month.rawValue
     @State private var mode: CalendarGridMode = .month
@@ -140,6 +141,11 @@ struct CalendarHomeView: View {
                 mode = first
             }
         }
+        .onChange(of: calendarEventViewFilter.cacheKey) { _, _ in
+            selectedEventIDs = selectedEventIDs.filter { eventID in
+                model.event(id: eventID).map(calendarEventViewFilter.allows) ?? false
+            }
+        }
     }
 
     @ViewBuilder
@@ -266,7 +272,7 @@ struct CalendarHomeView: View {
     }
 
     private var selectedEvents: [CalendarEventMirror] {
-        model.events.filter { selectedEventIDs.contains($0.id) }
+        model.events.filter { selectedEventIDs.contains($0.id) && calendarEventViewFilter.allows($0) }
     }
 
     // CalendarGridMode.allCases filtered by user-hidden set from Layout settings.
@@ -677,7 +683,17 @@ struct CalendarHomeView: View {
             let key = day.timeIntervalSinceReferenceDate
             guard let eventIDs = model.eventsByDay[key], eventIDs.isEmpty == false else { continue }
             let entries = eventIDs.compactMap { model.event(id: $0) }
-            let filtered = entries.filter { selectedIDs.contains($0.calendarID) }
+            let q = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+            let filtered = entries.filter { event in
+                selectedIDs.contains(event.calendarID)
+                    && calendarEventViewFilter.allows(event)
+                    && (
+                        q.isEmpty
+                        || event.summary.localizedCaseInsensitiveContains(q)
+                        || event.details.localizedCaseInsensitiveContains(q)
+                        || event.location.localizedCaseInsensitiveContains(q)
+                    )
+            }
             guard filtered.isEmpty == false else { continue }
             bucket[day] = filtered.sorted { lhs, rhs in
                 if lhs.isAllDay != rhs.isAllDay { return lhs.isAllDay && rhs.isAllDay == false }
@@ -777,6 +793,7 @@ struct CalendarHomeView: View {
             .filter { event in
                 (model.settings.showCompletedItemsInCalendar || event.status != .cancelled)
                     && selectedCalendarIDs.contains(event.calendarID)
+                    && calendarEventViewFilter.allows(event)
                     && event.startDate < endOfDay
                     && event.endDate > startOfDay
             }

--- a/apps/apple/HotCrossBuns/Features/Calendar/CalendarSidebarFilters.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/CalendarSidebarFilters.swift
@@ -1,0 +1,328 @@
+import SwiftUI
+
+struct CalendarSidebarFilters: View {
+    @Environment(AppModel.self) private var model
+    @Binding var state: CalendarViewFilterState
+
+    private struct ColorOption: Identifiable {
+        let color: CalendarEventColor
+        let count: Int
+
+        var id: String { color.rawValue }
+    }
+
+    private struct TagOption: Identifiable {
+        let key: String
+        let title: String
+        let count: Int
+        let boundColorID: String?
+
+        var id: String { key }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            calendarSection
+            colorSection
+            tagSection
+        }
+        .hcbScaledPadding(.vertical, 8)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text("View filters")
+                .hcbFont(.caption, weight: .semibold)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+            if state.hasActiveFilters {
+                Button {
+                    state = .allVisible
+                } label: {
+                    Image(systemName: "arrow.counterclockwise")
+                }
+                .buttonStyle(.plain)
+                .help("Show all calendar events")
+                .accessibilityLabel("Clear calendar view filters")
+            }
+        }
+    }
+
+    private var calendarSection: some View {
+        filterSection(
+            title: "Calendars",
+            setAll: { state.visibleCalendarIDs = nil },
+            setNone: { state.visibleCalendarIDs = [] }
+        ) {
+            ForEach(model.calendarSnapshot.selectedCalendars) { calendar in
+                filterRow(
+                    title: calendar.summary,
+                    count: calendarEventCounts[calendar.id, default: 0],
+                    isOn: isCalendarVisible(calendar.id),
+                    swatch: AnyView(
+                        Circle()
+                            .fill(Color(hex: calendar.colorHex))
+                            .hcbScaledFrame(width: 9, height: 9)
+                    ),
+                    action: { setCalendar(calendar.id, visible: isCalendarVisible(calendar.id) == false) }
+                )
+                .accessibilityLabel("\(calendar.summary) calendar")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var colorSection: some View {
+        let options = colorOptions
+        if options.isEmpty == false {
+            filterSection(
+                title: "Colors",
+                setAll: { state.visibleColorIDs = nil },
+                setNone: { state.visibleColorIDs = [] }
+            ) {
+                ForEach(options) { option in
+                    filterRow(
+                        title: option.color.title,
+                        count: option.count,
+                        isOn: isColorVisible(option.color.rawValue),
+                        swatch: AnyView(colorSwatch(option.color)),
+                        action: { setColor(option.color.rawValue, visible: isColorVisible(option.color.rawValue) == false) }
+                    )
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var tagSection: some View {
+        let options = tagOptions
+        if options.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Tags")
+                    .hcbFont(.caption2, weight: .semibold)
+                    .foregroundStyle(.secondary)
+                Text("No event tags yet")
+                    .hcbFont(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        } else {
+            filterSection(
+                title: "Tags",
+                setAll: { state.visibleTagNames = nil },
+                setNone: { state.visibleTagNames = [] }
+            ) {
+                ForEach(options) { option in
+                    filterRow(
+                        title: option.title,
+                        count: option.count,
+                        isOn: isTagVisible(option.key),
+                        swatch: AnyView(tagSwatch(option.boundColorID)),
+                        action: { setTag(option.key, visible: isTagVisible(option.key) == false) }
+                    )
+                }
+            }
+        }
+    }
+
+    private func filterSection<Content: View>(
+        title: String,
+        setAll: @escaping () -> Void,
+        setNone: @escaping () -> Void,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 6) {
+                Text(title)
+                    .hcbFont(.caption2, weight: .semibold)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                Button("All", action: setAll)
+                    .buttonStyle(.plain)
+                    .hcbFont(.caption2)
+                    .help("Show all \(title.lowercased())")
+                Button("None", action: setNone)
+                    .buttonStyle(.plain)
+                    .hcbFont(.caption2)
+                    .help("Hide all \(title.lowercased())")
+            }
+            content()
+        }
+    }
+
+    private func filterRow(
+        title: String,
+        count: Int,
+        isOn: Bool,
+        swatch: AnyView,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 7) {
+                Image(systemName: isOn ? "checkmark.square.fill" : "square")
+                    .foregroundStyle(isOn ? AppColor.ember : .secondary)
+                    .hcbScaledFrame(width: 13)
+                swatch
+                Text(title)
+                    .hcbFont(.caption)
+                    .lineLimit(1)
+                    .foregroundStyle(AppColor.ink)
+                Spacer(minLength: 0)
+                Text("\(count)")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityValue(isOn ? "visible, \(count) events" : "hidden, \(count) events")
+    }
+
+    @ViewBuilder
+    private func colorSwatch(_ color: CalendarEventColor) -> some View {
+        if let hex = color.hex {
+            Circle()
+                .fill(Color(hex: hex))
+                .hcbScaledFrame(width: 9, height: 9)
+        } else {
+            Circle()
+                .strokeBorder(AppColor.cardStroke, lineWidth: 1)
+                .background(Circle().fill(AppColor.cardSurface))
+                .hcbScaledFrame(width: 9, height: 9)
+        }
+    }
+
+    @ViewBuilder
+    private func tagSwatch(_ boundColorID: String?) -> some View {
+        if let boundColorID,
+           let hex = CalendarEventColor(rawValue: boundColorID)?.hex {
+            Circle()
+                .fill(Color(hex: hex))
+                .hcbScaledFrame(width: 9, height: 9)
+        } else {
+            Image(systemName: "number")
+                .foregroundStyle(.secondary)
+                .hcbFont(.caption2)
+                .hcbScaledFrame(width: 9)
+        }
+    }
+
+    private var eligibleEvents: [CalendarEventMirror] {
+        let selectedIDs = model.calendarSnapshot.selectedCalendarIDs
+        return model.events.filter { event in
+            selectedIDs.contains(event.calendarID)
+                && (model.settings.showCompletedItemsInCalendar || event.status != .cancelled)
+        }
+    }
+
+    private var calendarEventCounts: [CalendarListMirror.ID: Int] {
+        Dictionary(uniqueKeysWithValues: model.calendarSnapshot.selectedCalendars.map { calendar in
+            (calendar.id, model.eventsByCalendar[calendar.id]?.count ?? 0)
+        })
+    }
+
+    private var colorOptions: [ColorOption] {
+        let counts = eligibleEvents.reduce(into: [String: Int]()) { result, event in
+            result[CalendarEventViewFilter.eventColorID(for: event), default: 0] += 1
+        }
+        let boundColorIDs = Set(model.settings.colorTagBindings.keys.map(CalendarEventViewFilter.normalizedColorID))
+        let ids = Set(counts.keys).union(boundColorIDs).filter { id in
+            id.isEmpty || CalendarEventColor(rawValue: id) != nil
+        }
+        return CalendarEventColor.allCases
+            .filter { ids.contains($0.rawValue) }
+            .map { ColorOption(color: $0, count: counts[$0.rawValue, default: 0]) }
+    }
+
+    private var tagOptions: [TagOption] {
+        let bindingIndex = CalendarEventViewFilter.colorTagIndex(from: model.settings.colorTagBindings)
+        var eventIDsByTag: [String: Set<CalendarEventMirror.ID>] = [:]
+        for event in eligibleEvents {
+            for tag in CalendarEventViewFilter.literalTagNames(in: event) {
+                eventIDsByTag[tag, default: []].insert(event.id)
+            }
+            let colorID = CalendarEventViewFilter.eventColorID(for: event)
+            for (tag, boundColorID) in bindingIndex where CalendarEventViewFilter.normalizedColorID(boundColorID) == colorID {
+                eventIDsByTag[tag, default: []].insert(event.id)
+            }
+        }
+        for tag in bindingIndex.keys where eventIDsByTag[tag] == nil {
+            eventIDsByTag[tag] = []
+        }
+        if let visibleTagNames = state.visibleTagNames {
+            for tag in visibleTagNames where eventIDsByTag[tag] == nil {
+                eventIDsByTag[tag] = []
+            }
+        }
+        return eventIDsByTag.map { entry in
+            TagOption(
+                key: entry.key,
+                title: "#\(entry.key)",
+                count: entry.value.count,
+                boundColorID: bindingIndex[entry.key]
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.count != rhs.count { return lhs.count > rhs.count }
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        }
+    }
+
+    private var availableCalendarIDs: Set<CalendarListMirror.ID> {
+        Set(model.calendarSnapshot.selectedCalendars.map(\.id))
+    }
+
+    private var availableColorIDs: Set<String> {
+        Set(colorOptions.map(\.id))
+    }
+
+    private var availableTagNames: Set<String> {
+        Set(tagOptions.map(\.key))
+    }
+
+    private func isCalendarVisible(_ id: CalendarListMirror.ID) -> Bool {
+        state.visibleCalendarIDs?.contains(id) ?? true
+    }
+
+    private func isColorVisible(_ id: String) -> Bool {
+        state.visibleColorIDs?.contains(id) ?? true
+    }
+
+    private func isTagVisible(_ key: String) -> Bool {
+        state.visibleTagNames?.contains(key) ?? true
+    }
+
+    private func setCalendar(_ id: CalendarListMirror.ID, visible: Bool) {
+        var visibleIDs = state.visibleCalendarIDs ?? availableCalendarIDs
+        if visible {
+            visibleIDs.insert(id)
+        } else {
+            visibleIDs.remove(id)
+        }
+        state.visibleCalendarIDs = visibleIDs == availableCalendarIDs ? nil : visibleIDs
+    }
+
+    private func setColor(_ id: String, visible: Bool) {
+        var visibleIDs = state.visibleColorIDs ?? availableColorIDs
+        if visible {
+            visibleIDs.insert(id)
+        } else {
+            visibleIDs.remove(id)
+        }
+        state.visibleColorIDs = visibleIDs == availableColorIDs ? nil : visibleIDs
+    }
+
+    private func setTag(_ key: String, visible: Bool) {
+        let normalized = CalendarEventViewFilter.normalizedTagName(key)
+        var visibleNames = state.visibleTagNames ?? availableTagNames
+        if visible {
+            visibleNames.insert(normalized)
+        } else {
+            visibleNames.remove(normalized)
+        }
+        state.visibleTagNames = visibleNames == availableTagNames ? nil : visibleNames
+    }
+}

--- a/apps/apple/HotCrossBuns/Features/Calendar/CalendarViewFilter.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/CalendarViewFilter.swift
@@ -1,0 +1,148 @@
+import Foundation
+import SwiftUI
+
+struct CalendarViewFilterState: Codable, Equatable, Sendable {
+    static let storageKey = "calendar.viewFilters.state.v1"
+
+    var visibleCalendarIDs: Set<CalendarListMirror.ID>?
+    var visibleColorIDs: Set<String>?
+    var visibleTagNames: Set<String>?
+
+    static let allVisible = CalendarViewFilterState(
+        visibleCalendarIDs: nil,
+        visibleColorIDs: nil,
+        visibleTagNames: nil
+    )
+
+    static func decoded(from rawValue: String) -> CalendarViewFilterState {
+        guard rawValue.isEmpty == false,
+              let data = rawValue.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(CalendarViewFilterState.self, from: data)
+        else {
+            return .allVisible
+        }
+        return decoded.normalized()
+    }
+
+    func encodedString() -> String {
+        let normalized = normalized()
+        guard normalized != .allVisible,
+              let data = try? JSONEncoder().encode(normalized),
+              let encoded = String(data: data, encoding: .utf8)
+        else {
+            return ""
+        }
+        return encoded
+    }
+
+    func normalized() -> CalendarViewFilterState {
+        CalendarViewFilterState(
+            visibleCalendarIDs: visibleCalendarIDs,
+            visibleColorIDs: visibleColorIDs.map { Set($0.map(CalendarEventViewFilter.normalizedColorID)) },
+            visibleTagNames: visibleTagNames.map { Set($0.map(CalendarEventViewFilter.normalizedTagName).filter { $0.isEmpty == false }) }
+        )
+    }
+
+    var hasActiveFilters: Bool {
+        visibleCalendarIDs != nil || visibleColorIDs != nil || visibleTagNames != nil
+    }
+}
+
+struct CalendarEventViewFilter: Equatable, Sendable {
+    var visibleCalendarIDs: Set<CalendarListMirror.ID>?
+    var visibleColorIDs: Set<String>?
+    var visibleTagNames: Set<String>?
+    var colorTagIndex: [String: String]
+
+    init(
+        state: CalendarViewFilterState = .allVisible,
+        colorTagBindings: [String: String] = [:]
+    ) {
+        let normalizedState = state.normalized()
+        self.visibleCalendarIDs = normalizedState.visibleCalendarIDs
+        self.visibleColorIDs = normalizedState.visibleColorIDs.map { Set($0.map(Self.normalizedColorID)) }
+        self.visibleTagNames = normalizedState.visibleTagNames
+        self.colorTagIndex = Self.colorTagIndex(from: colorTagBindings)
+    }
+
+    var cacheKey: String {
+        [
+            "cal=\(Self.cachePart(visibleCalendarIDs))",
+            "color=\(Self.cachePart(visibleColorIDs))",
+            "tag=\(Self.cachePart(visibleTagNames))",
+            "bindings=\(colorTagIndex.map { "\($0.key):\($0.value)" }.sorted().joined(separator: ","))"
+        ].joined(separator: "|")
+    }
+
+    func allows(_ event: CalendarEventMirror) -> Bool {
+        if let visibleCalendarIDs, visibleCalendarIDs.contains(event.calendarID) == false {
+            return false
+        }
+
+        let eventColorID = Self.eventColorID(for: event)
+        if let visibleColorIDs, visibleColorIDs.contains(eventColorID) == false {
+            return false
+        }
+
+        if let visibleTagNames {
+            guard visibleTagNames.isEmpty == false else { return false }
+            let literalTags = Self.literalTagNames(in: event)
+            if literalTags.isDisjoint(with: visibleTagNames) == false {
+                return true
+            }
+            return visibleTagNames.contains { tagName in
+                colorTagIndex[tagName].map(Self.normalizedColorID) == eventColorID
+            }
+        }
+
+        return true
+    }
+
+    static func eventColorID(for event: CalendarEventMirror) -> String {
+        CalendarEventColor.from(colorId: event.colorId).rawValue
+    }
+
+    static func literalTagNames(in event: CalendarEventMirror) -> Set<String> {
+        let fields = [event.summary, event.details, event.location]
+        return Set(fields.flatMap(TagExtractor.tags).map(normalizedTagName).filter { $0.isEmpty == false })
+    }
+
+    static func colorTagIndex(from bindings: [String: String]) -> [String: String] {
+        bindings.reduce(into: [String: String]()) { result, entry in
+            let colorID = normalizedColorID(entry.key)
+            let tagName = normalizedTagName(entry.value)
+            guard colorID.isEmpty == false, tagName.isEmpty == false else { return }
+            result[tagName] = colorID
+        }
+    }
+
+    static func normalizedTagName(_ value: String) -> String {
+        var trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        while trimmed.first == "#" {
+            trimmed.removeFirst()
+        }
+        return trimmed
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .lowercased()
+    }
+
+    static func normalizedColorID(_ value: String) -> String {
+        CalendarEventColor(rawValue: value)?.rawValue ?? CalendarEventColor.defaultColor.rawValue
+    }
+
+    private static func cachePart(_ values: Set<String>?) -> String {
+        guard let values else { return "*" }
+        return values.sorted().joined(separator: ",")
+    }
+}
+
+private struct CalendarEventViewFilterKey: EnvironmentKey {
+    static let defaultValue = CalendarEventViewFilter()
+}
+
+extension EnvironmentValues {
+    var calendarEventViewFilter: CalendarEventViewFilter {
+        get { self[CalendarEventViewFilterKey.self] }
+        set { self[CalendarEventViewFilterKey.self] = newValue }
+    }
+}

--- a/apps/apple/HotCrossBuns/Features/Calendar/DayGridView.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/DayGridView.swift
@@ -6,6 +6,7 @@ struct DayGridView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.hcbAppBackgroundConfiguration) private var backgroundConfiguration
+    @Environment(\.calendarEventViewFilter) private var calendarEventViewFilter
     @Binding var anchorDate: Date
     var searchQuery: String = ""
 
@@ -60,6 +61,7 @@ struct DayGridView: View {
         let bucket = (model.eventsByDay[key] ?? []).compactMap { model.event(id: $0) }
         let filtered = bucket.filter { event in
             selectedIDs.contains(event.calendarID)
+                && calendarEventViewFilter.allows(event)
                 && model.settings.shouldHidePastEvent(event, now: now) == false
         }
         let q = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()

--- a/apps/apple/HotCrossBuns/Features/Calendar/MonthGridView.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/MonthGridView.swift
@@ -24,6 +24,7 @@ struct MonthGridView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.hcbAppBackgroundConfiguration) private var backgroundConfiguration
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.calendarEventViewFilter) private var calendarEventViewFilter
     @AppStorage(CalendarMonthScrollWindow.pastMonthsKey) private var configuredPastMonths = CalendarMonthScrollWindow.defaultPastMonths
     @AppStorage(CalendarMonthScrollWindow.futureMonthsKey) private var configuredFutureMonths = CalendarMonthScrollWindow.defaultFutureMonths
     @Binding var anchorDate: Date
@@ -167,6 +168,7 @@ struct MonthGridView: View {
         var anchorDate: Date
         var weekStarts: [Date]
         var selectedCalendarIDs: Set<CalendarListMirror.ID>
+        var eventViewFilter: CalendarEventViewFilter
         var visibleTaskListIDs: Set<TaskListMirror.ID>
         var searchQuery: String
         var eventsByDay: [TimeInterval: [CalendarEventMirror.ID]]
@@ -330,7 +332,7 @@ struct MonthGridView: View {
         // dataRevision replaces the prior model.events.count fingerprint —
         // renames / reschedules / recolors with unchanged total count now
         // bust the cache correctly.
-        return "\(selectedIds)|\(visibleTaskListKey)|\(searchQuery)|\(windowKey)|\(model.dataRevision)"
+        return "\(selectedIds)|\(calendarEventViewFilter.cacheKey)|\(visibleTaskListKey)|\(searchQuery)|\(windowKey)|\(model.dataRevision)"
     }
 
     private var windowKey: String {
@@ -368,6 +370,7 @@ struct MonthGridView: View {
             anchorDate: anchorDate,
             weekStarts: weekStarts,
             selectedCalendarIDs: model.calendarSnapshot.selectedCalendarIDs,
+            eventViewFilter: calendarEventViewFilter,
             visibleTaskListIDs: model.visibleTaskListIDs,
             searchQuery: searchQuery,
             eventsByDay: model.eventsByDay,
@@ -472,6 +475,7 @@ struct MonthGridView: View {
             for eventID in payload.eventsByDay[key] ?? [] where seen.insert(eventID).inserted {
                 guard let event = eventByID[eventID],
                       payload.selectedCalendarIDs.contains(event.calendarID) else { continue }
+                guard payload.eventViewFilter.allows(event) else { continue }
                 let matchesSearch: Bool
                 if q.isEmpty {
                     matchesSearch = true

--- a/apps/apple/HotCrossBuns/Features/Calendar/WeekGridView.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/WeekGridView.swift
@@ -8,6 +8,7 @@ struct WeekGridView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.hcbAppBackgroundConfiguration) private var backgroundConfiguration
+    @Environment(\.calendarEventViewFilter) private var calendarEventViewFilter
     @Binding var anchorDate: Date
     var searchQuery: String = ""
     @Binding var selectedEventIDs: Set<String>
@@ -121,7 +122,7 @@ struct WeekGridView: View {
         let start = weekDays.first.map { "\($0.timeIntervalSinceReferenceDate)" } ?? ""
         // dataRevision replaces event-count fingerprint so edits that keep
         // the count unchanged still invalidate the cache. See MonthGridView.
-        return "\(selectedIds)|\(searchQuery)|\(start)|\(model.dataRevision)"
+        return "\(selectedIds)|\(calendarEventViewFilter.cacheKey)|\(searchQuery)|\(start)|\(model.dataRevision)"
     }
 
     private func rebuildWeekCacheIfNeeded() {
@@ -152,6 +153,7 @@ struct WeekGridView: View {
                 base.append(contentsOf: bucket.compactMap { model.event(id: $0) })
             }
         }
+        base = base.filter(calendarEventViewFilter.allows)
         let q = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard q.isEmpty == false else { return base }
         return base.filter { event in

--- a/apps/apple/HotCrossBuns/Features/Calendar/YearGridView.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/YearGridView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct YearGridView: View {
     @Environment(AppModel.self) private var model
     @Environment(\.hcbAppBackgroundConfiguration) private var backgroundConfiguration
+    @Environment(\.calendarEventViewFilter) private var calendarEventViewFilter
     @Binding var anchorDate: Date
     let onPickDay: (Date) -> Void
 
@@ -44,7 +45,7 @@ struct YearGridView: View {
             guard key >= yearStartKey && key < yearEndKey else { continue }
             let count = eventIDs.reduce(into: 0) { acc, eventID in
                 guard let event = model.event(id: eventID) else { return }
-                if selected.contains(event.calendarID) { acc += 1 }
+                if selected.contains(event.calendarID), calendarEventViewFilter.allows(event) { acc += 1 }
             }
             if count > 0 {
                 counts[Date(timeIntervalSinceReferenceDate: key)] = count

--- a/apps/apple/HotCrossBunsMacTests/CalendarViewFilterTests.swift
+++ b/apps/apple/HotCrossBunsMacTests/CalendarViewFilterTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import HotCrossBunsMac
+
+final class CalendarViewFilterTests: XCTestCase {
+    private let calendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
+
+    private func day(_ y: Int, _ m: Int, _ d: Int, hour: Int = 0) -> Date {
+        calendar.date(from: DateComponents(year: y, month: m, day: d, hour: hour))!
+    }
+
+    private func event(
+        id: String,
+        calendarID: String = "work",
+        summary: String = "Planning",
+        details: String = "",
+        location: String = "",
+        colorId: String? = nil
+    ) -> CalendarEventMirror {
+        CalendarEventMirror(
+            id: id,
+            calendarID: calendarID,
+            summary: summary,
+            details: details,
+            startDate: day(2026, 5, 11, hour: 9),
+            endDate: day(2026, 5, 11, hour: 10),
+            isAllDay: false,
+            status: .confirmed,
+            recurrence: [],
+            etag: nil,
+            updatedAt: nil,
+            location: location,
+            colorId: colorId
+        )
+    }
+
+    func testEmptyPersistedStateDecodesToAllVisible() {
+        XCTAssertEqual(CalendarViewFilterState.decoded(from: ""), .allVisible)
+        XCTAssertEqual(CalendarViewFilterState.allVisible.encodedString(), "")
+    }
+
+    func testPersistedStateRoundTripsAndNormalizesTags() {
+        let state = CalendarViewFilterState(
+            visibleCalendarIDs: ["work"],
+            visibleColorIDs: [CalendarEventColor.sage.rawValue],
+            visibleTagNames: ["#Launch", " Ops "]
+        )
+
+        let decoded = CalendarViewFilterState.decoded(from: state.encodedString())
+
+        XCTAssertEqual(decoded.visibleCalendarIDs, ["work"])
+        XCTAssertEqual(decoded.visibleColorIDs, [CalendarEventColor.sage.rawValue])
+        XCTAssertEqual(decoded.visibleTagNames, ["launch", "ops"])
+    }
+
+    func testCalendarFilterAllowsOnlyVisibleCalendarIDs() {
+        let filter = CalendarEventViewFilter(
+            state: CalendarViewFilterState(visibleCalendarIDs: ["work"], visibleColorIDs: nil, visibleTagNames: nil)
+        )
+
+        XCTAssertTrue(filter.allows(event(id: "visible", calendarID: "work")))
+        XCTAssertFalse(filter.allows(event(id: "hidden", calendarID: "personal")))
+    }
+
+    func testColorFilterDistinguishesDefaultAndExplicitColors() {
+        let defaultOnly = CalendarEventViewFilter(
+            state: CalendarViewFilterState(visibleCalendarIDs: nil, visibleColorIDs: [CalendarEventColor.defaultColor.rawValue], visibleTagNames: nil)
+        )
+        let peacockOnly = CalendarEventViewFilter(
+            state: CalendarViewFilterState(visibleCalendarIDs: nil, visibleColorIDs: [CalendarEventColor.peacock.rawValue], visibleTagNames: nil)
+        )
+
+        XCTAssertTrue(defaultOnly.allows(event(id: "default", colorId: nil)))
+        XCTAssertFalse(defaultOnly.allows(event(id: "blue", colorId: CalendarEventColor.peacock.rawValue)))
+        XCTAssertTrue(peacockOnly.allows(event(id: "blue", colorId: CalendarEventColor.peacock.rawValue)))
+    }
+
+    func testLiteralHashtagFilterMatchesSummaryDetailsAndLocation() {
+        let filter = CalendarEventViewFilter(
+            state: CalendarViewFilterState(visibleCalendarIDs: nil, visibleColorIDs: nil, visibleTagNames: ["launch"])
+        )
+
+        XCTAssertTrue(filter.allows(event(id: "summary", summary: "Prep #Launch")))
+        XCTAssertTrue(filter.allows(event(id: "details", details: "Bring #launch notes")))
+        XCTAssertTrue(filter.allows(event(id: "location", location: "Room #launch")))
+        XCTAssertFalse(filter.allows(event(id: "other", summary: "Prep #ops")))
+    }
+
+    func testColorBindingTagMatchesMappedEventColor() {
+        let filter = CalendarEventViewFilter(
+            state: CalendarViewFilterState(visibleCalendarIDs: nil, visibleColorIDs: nil, visibleTagNames: ["marketing"]),
+            colorTagBindings: [CalendarEventColor.sage.rawValue: "#Marketing"]
+        )
+
+        XCTAssertTrue(filter.allows(event(id: "mapped", colorId: CalendarEventColor.sage.rawValue)))
+        XCTAssertFalse(filter.allows(event(id: "unmapped", colorId: CalendarEventColor.tomato.rawValue)))
+    }
+
+    func testSectionsCombineWithAndSemantics() {
+        let filter = CalendarEventViewFilter(
+            state: CalendarViewFilterState(
+                visibleCalendarIDs: ["work"],
+                visibleColorIDs: [CalendarEventColor.tomato.rawValue],
+                visibleTagNames: ["urgent"]
+            )
+        )
+
+        XCTAssertTrue(filter.allows(event(
+            id: "match",
+            calendarID: "work",
+            summary: "Incident #urgent",
+            colorId: CalendarEventColor.tomato.rawValue
+        )))
+        XCTAssertFalse(filter.allows(event(
+            id: "wrong-calendar",
+            calendarID: "personal",
+            summary: "Incident #urgent",
+            colorId: CalendarEventColor.tomato.rawValue
+        )))
+        XCTAssertFalse(filter.allows(event(
+            id: "wrong-color",
+            calendarID: "work",
+            summary: "Incident #urgent",
+            colorId: CalendarEventColor.sage.rawValue
+        )))
+        XCTAssertFalse(filter.allows(event(
+            id: "wrong-tag",
+            calendarID: "work",
+            summary: "Incident #later",
+            colorId: CalendarEventColor.tomato.rawValue
+        )))
+    }
+}


### PR DESCRIPTION
## Summary
- keep the loading overlay spinner animating through completion
- add view-only Calendar sidebar filters for calendars, event colors, literal hashtags, and configured color-tag bindings
- apply the shared event filter across agenda, day, week, month, and year calendar views

## Validation
- make test-one SUITE=AccessibilityFoundationsTests
- make test-one SUITE=CalendarViewFilterTests
- make build
- git diff --check

## Notes
- Calendar filters are local view preferences only; they do not change Google data or selected-calendar sync settings.