### PR TITLE
Fix explicit Mac controls

### DIFF
--- a/apps/apple/HotCrossBuns/Features/Calendar/DayGridView.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/DayGridView.swift
@@ -174,39 +174,9 @@ struct DayGridView: View {
                                         dayStart: dayStart,
                                         calendar: calendar
                                     )
-                                    if let availabilitySelection {
-                                        let end = calendar.date(
-                                            byAdding: .minute,
-                                            value: max(15, availabilitySelection.defaultDurationMinutes),
-                                            to: start
-                                        ) ?? start.addingTimeInterval(1800)
-                                        selectAvailabilitySlot(
-                                            AvailabilitySlot(startDate: start, endDate: end),
-                                            using: availabilitySelection
-                                        )
-                                        return
-                                    }
-                                    flashTimedStart(start)
-                                    capturedRouter?.present(.quickCreate(start, allDay: false))
+                                    createTimedSlot(start: start, router: capturedRouter)
                                 }
                         )
-                        .overlay(alignment: .topLeading) {
-                            // Momentary tint over the tapped hour slot so the
-                            // click lands visibly before the popover paints.
-                            if let flash = flashTimedSlot {
-                                let minutesIntoDay = flash.timeIntervalSince(dayStart) / 60.0
-                                let startHourOffset = Double(hourStart) * 60.0
-                                let y = CGFloat(max(0, minutesIntoDay - startHourOffset)) / 60.0 * hourHeight
-                                RoundedRectangle(cornerRadius: 6)
-                                    .fill(AppColor.ember.opacity(0.22))
-                                    .frame(height: hourHeight * 0.5)
-                                    .offset(x: 56, y: y)
-                                    .padding(.trailing, 8)
-                                    .allowsHitTesting(false)
-                                    .transition(.opacity)
-                            }
-                        }
-                        .animation(HCBMotion.animation(.easeOut(duration: 0.18), reduceMotion: calendarGridReduceMotion), value: flashTimedSlot)
                     GeometryReader { geo in
                         ZStack(alignment: .topLeading) {
                             availabilitySlotOverlays(
@@ -222,6 +192,8 @@ struct DayGridView: View {
                     }
                     .frame(height: CGFloat(hourEnd - hourStart) * hourHeight)
                     .allowsHitTesting(true)
+                    dayTimedSlotButtons(dayStart: dayStart, router: capturedRouter)
+                    timedSlotFlashOverlay(dayStart: dayStart)
                     if let offset = currentTimeOffset() {
                         Rectangle()
                             .fill(AppColor.ember)
@@ -232,6 +204,81 @@ struct DayGridView: View {
                 .frame(minHeight: CGFloat(hourEnd - hourStart) * hourHeight)
             }
         }
+    }
+
+    @ViewBuilder
+    private func timedSlotFlashOverlay(dayStart: Date) -> some View {
+        // Momentary tint over the tapped hour slot so the click lands visibly
+        // before the popover paints.
+        if let flash = flashTimedSlot {
+            let minutesIntoDay = flash.timeIntervalSince(dayStart) / 60.0
+            let startHourOffset = Double(hourStart) * 60.0
+            let y = CGFloat(max(0, minutesIntoDay - startHourOffset)) / 60.0 * hourHeight
+            RoundedRectangle(cornerRadius: 6)
+                .fill(AppColor.ember.opacity(0.22))
+                .frame(height: hourHeight * 0.5)
+                .offset(x: 56, y: y)
+                .padding(.trailing, 8)
+                .allowsHitTesting(false)
+                .transition(.opacity)
+                .animation(HCBMotion.animation(.easeOut(duration: 0.18), reduceMotion: calendarGridReduceMotion), value: flashTimedSlot)
+        }
+    }
+
+    private func dayTimedSlotButtons(dayStart: Date, router capturedRouter: RouterPath?) -> some View {
+        VStack(spacing: 0) {
+            ForEach(hourStart..<hourEnd, id: \.self) { hour in
+                let start = calendar.date(byAdding: .hour, value: hour, to: dayStart) ?? dayStart
+                HStack {
+                    Spacer(minLength: 0)
+                    Button {
+                        createTimedSlot(start: start, router: capturedRouter)
+                    } label: {
+                        Image(systemName: "plus.circle")
+                            .imageScale(.small)
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.mini)
+                    .help(timedSlotActionTitle(for: start))
+                    .accessibilityLabel(timedSlotAccessibilityLabel(for: start))
+                }
+                .hcbScaledFrame(width: 54, height: hourHeight, alignment: .topTrailing)
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func createTimedSlot(start: Date, router capturedRouter: RouterPath?) {
+        if let availabilitySelection {
+            let end = calendar.date(
+                byAdding: .minute,
+                value: max(15, availabilitySelection.defaultDurationMinutes),
+                to: start
+            ) ?? start.addingTimeInterval(1800)
+            selectAvailabilitySlot(
+                AvailabilitySlot(startDate: start, endDate: end),
+                using: availabilitySelection
+            )
+            return
+        }
+        flashTimedStart(start)
+        capturedRouter?.present(.quickCreate(start, allDay: false))
+    }
+
+    private func timedSlotActionTitle(for start: Date) -> String {
+        let time = start.formatted(.dateTime.hour().minute())
+        if availabilitySelection != nil {
+            return "Select availability at \(time)"
+        }
+        return "New event at \(time)"
+    }
+
+    private func timedSlotAccessibilityLabel(for start: Date) -> String {
+        let dateTime = start.formatted(.dateTime.weekday(.wide).month(.wide).day().hour().minute())
+        if availabilitySelection != nil {
+            return "Select availability on \(dateTime)"
+        }
+        return "New event on \(dateTime)"
     }
 
     private var hourGridBackground: some View {

--- a/apps/apple/HotCrossBuns/Features/Calendar/LocationMapPreview.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/LocationMapPreview.swift
@@ -37,27 +37,31 @@ struct LocationMapPreview: View {
     var body: some View {
         Group {
             if let coord = coordinate {
-                Map(initialPosition: .region(region(for: coord))) {
-                    Marker(resolvedLocation.isEmpty ? locationText : resolvedLocation, coordinate: coord)
-                        .tint(AppColor.ember)
+                Button {
+                    isPresentingFullView = true
+                } label: {
+                    Map(initialPosition: .region(region(for: coord))) {
+                        Marker(resolvedLocation.isEmpty ? locationText : resolvedLocation, coordinate: coord)
+                            .tint(AppColor.ember)
+                    }
+                    .allowsHitTesting(false)
                 }
+                .buttonStyle(.plain)
                 .frame(height: 140)
                 .clipShape(RoundedRectangle(cornerRadius: 10))
                 .overlay(
                     RoundedRectangle(cornerRadius: 10)
                         .strokeBorder(AppColor.cardStroke, lineWidth: 0.6)
                 )
-                // Tap the map body itself (not a button) expands. Keeps the
-                // target large for trackpad clicks; the corner chip is a
-                // discoverability hint rather than the only affordance.
                 .contentShape(RoundedRectangle(cornerRadius: 10))
-                .onTapGesture { isPresentingFullView = true }
                 .overlay(alignment: .topLeading) {
                     expandChip
                 }
                 .overlay(alignment: .topTrailing) {
                     mapsChip(coord: coord)
                 }
+                .accessibilityLabel("Open full map")
+                .accessibilityHint(fullMapAccessibilityHint)
             } else if isGeocoding {
                 HStack(spacing: 8) {
                     ProgressView().controlSize(.small)
@@ -75,6 +79,13 @@ struct LocationMapPreview: View {
         .sheet(isPresented: $isPresentingFullView) {
             LocationFullView(locationText: $locationText, isEditable: isEditable)
         }
+    }
+
+    private var fullMapAccessibilityHint: String {
+        let label = resolvedLocation.isEmpty ? locationText : resolvedLocation
+        return label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "Shows the location in a larger map view."
+            : "Shows \(label) in a larger map view."
     }
 
     private var expandChip: some View {

--- a/apps/apple/HotCrossBuns/Features/Calendar/MonthGridView.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/MonthGridView.swift
@@ -1278,6 +1278,7 @@ struct MonthGridView: View {
                             .fill(snapshot.isToday ? AppColor.ember.opacity(0.25) : .clear)
                     )
                 Spacer(minLength: 0)
+                monthCellCreateMenu(dayStart: dayStart, dateLabel: snapshot.accessibilityDateLabel)
             }
             if bandReserve > 0 {
                 Color.clear.frame(height: bandReserve)
@@ -1411,6 +1412,25 @@ struct MonthGridView: View {
             }
             return true
         }
+    }
+
+    private func monthCellCreateMenu(dayStart: Date, dateLabel: String) -> some View {
+        Menu {
+            Button("New event...") {
+                router?.present(.quickCreate(dayStart, allDay: false))
+            }
+            Button("New all-day event...") {
+                router?.present(.quickCreate(dayStart, allDay: true))
+            }
+        } label: {
+            Image(systemName: "plus.circle")
+                .imageScale(.small)
+        }
+        .menuStyle(.borderlessButton)
+        .controlSize(.mini)
+        .fixedSize()
+        .help("Create on \(dateLabel)")
+        .accessibilityLabel("Create on \(dateLabel)")
     }
 
     // How many band events for this specific day are visible in the overlay

--- a/apps/apple/HotCrossBuns/Features/Calendar/QuickCreatePopover.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/QuickCreatePopover.swift
@@ -2,8 +2,7 @@ import SwiftUI
 
 // Single unified popover for click-to-create + drag-to-create events and
 // tasks. Apple-Calendar-inspired layout: title row with color swatch,
-// location row, collapsible date section (click the summary to expand,
-// tap outside the date panel to collapse), invitees, notes.
+// location row, collapsible date section, invitees, notes.
 //
 // Default: all top-level fields are visible up-front. The date section
 // itself toggles on click. Users who want the pre-§7.01 compact
@@ -53,8 +52,7 @@ struct QuickCreatePopover: View {
     // AppSettings.quickCreateExpandedByDefault is false. True by default so
     // the popover starts fully detailed.
     @State private var showOptionalFields: Bool = true
-    // Inner date-panel expansion. Independent of the outer collapse. Click
-    // anywhere in the popover body that is not the date panel to collapse.
+    // Inner date-panel expansion. Independent of the outer compact mode.
     @State private var isDatePanelExpanded: Bool = false
 
     // Editable event fields
@@ -84,10 +82,7 @@ struct QuickCreatePopover: View {
     @State private var taskDueDate: Date = Date()
     @State private var hasDueDate: Bool = true
     // Per-section expansion for the task popover (Apple Reminders style).
-    // Tapping a card expands it; tapping anywhere outside the card in the
-    // popover body collapses it.
     @State private var isTaskDateCardExpanded: Bool = false
-    @State private var isTaskListCardExpanded: Bool = false
 
     private struct TaskListTagMatch {
         let list: TaskListMirror
@@ -149,20 +144,6 @@ struct QuickCreatePopover: View {
                 }
                 .hcbScaledPadding(.horizontal, 14)
                 .hcbScaledPadding(.vertical, 12)
-                // Empty-area taps inside the scroll view collapse the
-                // date panel. Interactive widgets (pickers, buttons,
-                // fields) consume their own taps first so they don't
-                // trigger this gesture.
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    if isDatePanelExpanded || isTaskDateCardExpanded || isTaskListCardExpanded {
-                        HCBMotion.perform(reduceMotion: reduceMotion, animation: .easeInOut(duration: 0.14)) {
-                            isDatePanelExpanded = false
-                            isTaskDateCardExpanded = false
-                            isTaskListCardExpanded = false
-                        }
-                    }
-                }
             }
             .frame(maxHeight: 520)
             Divider()
@@ -414,8 +395,8 @@ struct QuickCreatePopover: View {
         )
     }
 
-    // Click-to-expand date panel. Collapsed: one-line summary + hint.
-    // Expanded: editable fields. Outer body's tapGesture collapses.
+    // Collapsed: one-line summary + hint. Expanded: editable fields with an
+    // explicit collapse control for keyboard and VoiceOver users.
     private var datePanel: some View {
         VStack(alignment: .leading, spacing: 0) {
             if isDatePanelExpanded == false {
@@ -438,11 +419,6 @@ struct QuickCreatePopover: View {
             } else {
                 expandedDatePanel
                     .hcbScaledPadding(10)
-                    .contentShape(Rectangle())
-                    // Swallow taps inside the expanded panel so the
-                    // outer ScrollView's collapse gesture doesn't fire
-                    // when the user interacts with a picker/toggle.
-                    .onTapGesture { /* no-op */ }
             }
         }
         .background(
@@ -477,6 +453,15 @@ struct QuickCreatePopover: View {
 
     private var expandedDatePanel: some View {
         VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Label("Date and time", systemImage: "calendar")
+                    .hcbFont(.caption, weight: .semibold)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                collapseEditorButton("Collapse date options") {
+                    isDatePanelExpanded = false
+                }
+            }
             Toggle("All Day", isOn: $isAllDay)
                 .toggleStyle(.switch)
                 .tint(Color.accentColor)
@@ -542,6 +527,19 @@ struct QuickCreatePopover: View {
         }
     }
 
+    private func collapseEditorButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button {
+            HCBMotion.perform(reduceMotion: reduceMotion, animation: .easeInOut(duration: 0.14), action)
+        } label: {
+            Label(title, systemImage: "chevron.up")
+                .labelStyle(.iconOnly)
+        }
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+        .help(title)
+        .accessibilityLabel(title)
+    }
+
     private func alertLabel(for minutes: Int) -> String {
         switch minutes {
         case 0: return "At time"
@@ -605,38 +603,47 @@ struct QuickCreatePopover: View {
         )
     }
 
-    // Date card — collapsed shows Date label + toggle + subtitle; tap
-    // card to expand the inline DatePicker.
+    // Date card — collapsed shows Date label + toggle + subtitle; the
+    // disclosure button expands the inline DatePicker.
     private var taskDateCard: some View {
         VStack(spacing: 0) {
-            Button {
-                HCBMotion.perform(reduceMotion: reduceMotion, animation: .easeInOut(duration: 0.14)) { isTaskDateCardExpanded.toggle() }
-            } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "calendar")
-                        .hcbFont(.body)
-                        .foregroundStyle(.secondary)
-                        .hcbScaledFrame(width: 22)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Date")
-                            .hcbFont(.body)
-                            .foregroundStyle(AppColor.ink)
-                        if hasDueDate {
-                            Text(taskDueDate.formatted(.dateTime.weekday(.wide).day().month(.wide).year()))
-                                .hcbFont(.subheadline)
-                                .foregroundStyle(.secondary)
-                        }
+            HStack(spacing: 10) {
+                Button {
+                    HCBMotion.perform(reduceMotion: reduceMotion, animation: .easeInOut(duration: 0.14)) {
+                        isTaskDateCardExpanded.toggle()
                     }
-                    Spacer(minLength: 8)
-                    Toggle("", isOn: $hasDueDate)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
-                        .tint(Color.accentColor)
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "calendar")
+                            .hcbFont(.body)
+                            .foregroundStyle(.secondary)
+                            .hcbScaledFrame(width: 22)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Date")
+                                .hcbFont(.body)
+                                .foregroundStyle(AppColor.ink)
+                            if hasDueDate {
+                                Text(taskDueDate.formatted(.dateTime.weekday(.wide).day().month(.wide).year()))
+                                    .hcbFont(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer(minLength: 8)
+                        Image(systemName: isTaskDateCardExpanded ? "chevron.up" : "chevron.down")
+                            .hcbFont(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .contentShape(Rectangle())
                 }
-                .hcbScaledPadding(10)
-                .contentShape(Rectangle())
+                .buttonStyle(.plain)
+                .accessibilityLabel(isTaskDateCardExpanded ? "Collapse task date" : "Expand task date")
+
+                Toggle("", isOn: $hasDueDate)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .tint(Color.accentColor)
             }
-            .buttonStyle(.plain)
+            .hcbScaledPadding(10)
             if isTaskDateCardExpanded, hasDueDate {
                 Divider().hcbScaledPadding(.horizontal, 10)
                 HStack {
@@ -646,7 +653,6 @@ struct QuickCreatePopover: View {
                         .datePickerStyle(.stepperField)
                 }
                 .hcbScaledPadding(10)
-                .onTapGesture { /* swallow */ }
             }
         }
         .background(

--- a/apps/apple/HotCrossBuns/Features/Calendar/WeekGridView.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/WeekGridView.swift
@@ -172,11 +172,14 @@ struct WeekGridView: View {
         // GeometryReader closures have shown propagation gaps).
         let capturedRouter = router
         return HStack(spacing: 0) {
-            Text("All-day")
-                .hcbFont(.caption2, weight: .semibold)
-                .foregroundStyle(.secondary)
-                .hcbScaledFrame(width: 54, alignment: .trailing)
-                .hcbScaledPadding(.trailing, 6)
+            HStack(spacing: 3) {
+                Text("All-day")
+                    .hcbFont(.caption2, weight: .semibold)
+                    .foregroundStyle(.secondary)
+                weekAllDayCreateMenu(days: snapshot.days, router: capturedRouter)
+            }
+            .hcbScaledFrame(width: 54, alignment: .trailing)
+            .hcbScaledPadding(.trailing, 4)
             GeometryReader { geo in
                 let columnWidth = geo.size.width / CGFloat(max(snapshot.days.count, 1))
                 let laneHeight: CGFloat = 22
@@ -247,6 +250,25 @@ struct WeekGridView: View {
         .frame(minHeight: stripHeight, idealHeight: stripHeight, maxHeight: stripHeight)
         .clipped()
         .hcbScaledPadding(.vertical, 4)
+    }
+
+    private func weekAllDayCreateMenu(days: [Date], router capturedRouter: RouterPath?) -> some View {
+        Menu {
+            ForEach(Array(days.enumerated()), id: \.offset) { _, day in
+                let dayStart = calendar.startOfDay(for: day)
+                Button(dayStart.formatted(.dateTime.weekday(.wide).month(.abbreviated).day())) {
+                    capturedRouter?.present(.quickCreate(dayStart, allDay: true))
+                }
+            }
+        } label: {
+            Image(systemName: "plus.circle")
+                .imageScale(.small)
+        }
+        .menuStyle(.borderlessButton)
+        .controlSize(.mini)
+        .fixedSize()
+        .help("New all-day event")
+        .accessibilityLabel("New all-day event")
     }
 
     private func hiddenAllDaySpanCount(onColumn column: Int, spans: [CalendarWeekDisplaySnapshot.AllDaySpan]) -> Int {
@@ -416,7 +438,7 @@ struct WeekGridView: View {
         // reliable router reference (see allDayStrip for rationale).
         let capturedRouter = router
         return HStack(alignment: .top, spacing: 0) {
-            hoursColumn
+            hoursColumn(days: snapshot.days, router: capturedRouter)
             GeometryReader { geo in
                 let columnWidth = geo.size.width / CGFloat(max(snapshot.days.count, 1))
                 let totalHeight = CGFloat(hourEnd - hourStart) * hourHeight
@@ -577,21 +599,54 @@ struct WeekGridView: View {
         }
     }
 
-    private var hoursColumn: some View {
+    private func hoursColumn(days: [Date], router capturedRouter: RouterPath?) -> some View {
         VStack(spacing: 0) {
             ForEach(hourStart..<hourEnd, id: \.self) { hour in
-                HStack {
-                    Spacer()
+                HStack(spacing: 4) {
                     Text(labelForHour(hour))
                         .hcbFont(.caption2)
                         .foregroundStyle(.secondary)
                         .offset(y: -6)
-                        .hcbScaledPadding(.trailing, 6)
+                    weekTimedSlotMenu(hour: hour, days: days, router: capturedRouter)
                 }
                 .frame(height: hourHeight, alignment: .top)
             }
         }
         .hcbScaledFrame(width: 54)
+    }
+
+    private func weekTimedSlotMenu(hour: Int, days: [Date], router capturedRouter: RouterPath?) -> some View {
+        Menu {
+            ForEach(Array(days.enumerated()), id: \.offset) { _, day in
+                let dayStart = calendar.startOfDay(for: day)
+                let start = calendar.date(byAdding: .hour, value: hour, to: dayStart) ?? dayStart
+                Button(start.formatted(.dateTime.weekday(.wide).month(.abbreviated).day())) {
+                    createTimedSlot(start: start, router: capturedRouter)
+                }
+            }
+        } label: {
+            Image(systemName: "plus.circle")
+                .imageScale(.small)
+        }
+        .menuStyle(.borderlessButton)
+        .controlSize(.mini)
+        .fixedSize()
+        .help(weekTimedSlotActionTitle(hour: hour))
+        .accessibilityLabel(weekTimedSlotAccessibilityLabel(hour: hour))
+    }
+
+    private func weekTimedSlotActionTitle(hour: Int) -> String {
+        let dayStart = calendar.startOfDay(for: anchorDate)
+        let start = calendar.date(byAdding: .hour, value: hour, to: dayStart) ?? dayStart
+        let time = start.formatted(.dateTime.hour().minute())
+        return availabilitySelection == nil ? "New event at \(time)" : "Select availability at \(time)"
+    }
+
+    private func weekTimedSlotAccessibilityLabel(hour: Int) -> String {
+        let dayStart = calendar.startOfDay(for: anchorDate)
+        let start = calendar.date(byAdding: .hour, value: hour, to: dayStart) ?? dayStart
+        let time = start.formatted(.dateTime.hour().minute())
+        return availabilitySelection == nil ? "New event at \(time)" : "Select availability at \(time)"
     }
 
     private var gridLines: some View {
@@ -620,20 +675,7 @@ struct WeekGridView: View {
                 dayStart: startOfDay,
                 calendar: calendar,
                 onTap: { start in
-                    if let availabilitySelection {
-                        let end = calendar.date(
-                            byAdding: .minute,
-                            value: max(15, availabilitySelection.defaultDurationMinutes),
-                            to: start
-                        ) ?? start.addingTimeInterval(1800)
-                        selectAvailabilitySlot(
-                            AvailabilitySlot(startDate: start, endDate: end),
-                            using: availabilitySelection
-                        )
-                        return
-                    }
-                    flashTimedStart(start)
-                    capturedRouter?.present(.quickCreate(start, allDay: false))
+                    createTimedSlot(start: start, router: capturedRouter)
                 }
             )
             .dropDestination(for: DraggedTask.self) { items, location in
@@ -683,6 +725,23 @@ struct WeekGridView: View {
         .frame(width: width)
         .offset(x: xOffset)
         .animation(HCBMotion.animation(.easeOut(duration: 0.18), reduceMotion: calendarGridReduceMotion), value: flashTimedSlot)
+    }
+
+    private func createTimedSlot(start: Date, router capturedRouter: RouterPath?) {
+        if let availabilitySelection {
+            let end = calendar.date(
+                byAdding: .minute,
+                value: max(15, availabilitySelection.defaultDurationMinutes),
+                to: start
+            ) ?? start.addingTimeInterval(1800)
+            selectAvailabilitySlot(
+                AvailabilitySlot(startDate: start, endDate: end),
+                using: availabilitySelection
+            )
+            return
+        }
+        flashTimedStart(start)
+        capturedRouter?.present(.quickCreate(start, allDay: false))
     }
 
     // Tap-only hit-test layer for each day column. Multi-day drag is now

--- a/apps/apple/HotCrossBunsMacTests/AccessibilityFoundationsTests.swift
+++ b/apps/apple/HotCrossBunsMacTests/AccessibilityFoundationsTests.swift
@@ -69,6 +69,34 @@ final class AccessibilityFoundationsTests: XCTestCase {
         XCTAssertTrue(notes.contains(".accessibilityLabel(noteAccessibilityLabel)"))
     }
 
+    func testQuickCreateAndMapPreviewAvoidGestureOnlyControls() throws {
+        let quickCreate = try String(contentsOf: repoRoot.appending(path: "apps/apple/HotCrossBuns/Features/Calendar/QuickCreatePopover.swift"))
+        XCTAssertFalse(quickCreate.contains(".onTapGesture { /* no-op */ }"))
+        XCTAssertFalse(quickCreate.contains(".onTapGesture { /* swallow */ }"))
+        XCTAssertFalse(quickCreate.contains("isTaskListCardExpanded"))
+        XCTAssertTrue(quickCreate.contains("Collapse date options"))
+        XCTAssertTrue(quickCreate.contains("Expand task date"))
+
+        let mapPreview = try String(contentsOf: repoRoot.appending(path: "apps/apple/HotCrossBuns/Features/Calendar/LocationMapPreview.swift"))
+        XCTAssertFalse(mapPreview.contains(".onTapGesture { isPresentingFullView = true }"))
+        XCTAssertTrue(mapPreview.contains(".accessibilityLabel(\"Open full map\")"))
+        XCTAssertTrue(mapPreview.contains("fullMapAccessibilityHint"))
+
+        let dayGrid = try String(contentsOf: repoRoot.appending(path: "apps/apple/HotCrossBuns/Features/Calendar/DayGridView.swift"))
+        XCTAssertTrue(dayGrid.contains("dayTimedSlotButtons"))
+        XCTAssertTrue(dayGrid.contains("timedSlotAccessibilityLabel"))
+
+        let weekGrid = try String(contentsOf: repoRoot.appending(path: "apps/apple/HotCrossBuns/Features/Calendar/WeekGridView.swift"))
+        XCTAssertTrue(weekGrid.contains("weekAllDayCreateMenu"))
+        XCTAssertTrue(weekGrid.contains("weekTimedSlotMenu"))
+
+        let monthGrid = try String(contentsOf: repoRoot.appending(path: "apps/apple/HotCrossBuns/Features/Calendar/MonthGridView.swift"))
+        XCTAssertTrue(monthGrid.contains("monthCellCreateMenu"))
+
+        let actionCenter = try String(contentsOf: repoRoot.appending(path: "apps/apple/HotCrossBuns/Features/Status/ActionCenter.swift"))
+        XCTAssertFalse(actionCenter.contains("onTapGesture"))
+    }
+
     private var repoRoot: URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- Replace hidden/no-op quick-create collapse gestures with explicit focusable controls.
- Make map preview and Day/Week/Month calendar creation reachable through real buttons/menus while preserving click and drag shortcuts.
- Add accessibility regression coverage for the gesture-only control paths.

## Verification
- xcodebuild test -project apps/apple/HotCrossBuns.xcodeproj -scheme HotCrossBunsMac -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO

Closes #64