### PR TITLE
Add Mac calendar control polish

### DIFF
--- a/apps/apple/HotCrossBuns/App/AppCommands.swift
+++ b/apps/apple/HotCrossBuns/App/AppCommands.swift
@@ -81,15 +81,21 @@ struct CalendarCommandActions {
     var jumpForward: () -> Void
     var goToDate: () -> Void
     var focusSearch: () -> Void
+    var shareAvailability: () -> Void
     var showAgenda: () -> Void
     var showDay: () -> Void
     var showWeek: () -> Void
     var showMonth: () -> Void
+    var showMultiDay: () -> Void
+    var showYear: () -> Void
     var canNavigate: Bool
+    var canShareAvailability: Bool
     var canShowAgenda: Bool
     var canShowDay: Bool
     var canShowWeek: Bool
     var canShowMonth: Bool
+    var canShowMultiDay: Bool
+    var canShowYear: Bool
 }
 
 @MainActor
@@ -305,6 +311,11 @@ struct AppCommands: Commands {
                         .keyboardShortcut(focusSearch.key.keyEquivalent, modifiers: focusSearch.modifiers.eventModifiers)
                         .disabled(calendarActions.canNavigate == false)
 
+                    let shareAvailability = binding(.calendarShareAvailability)
+                    Button("Share Availability…") { calendarActions.shareAvailability() }
+                        .keyboardShortcut(shareAvailability.key.keyEquivalent, modifiers: shareAvailability.modifiers.eventModifiers)
+                        .disabled(calendarActions.canShareAvailability == false)
+
                     Divider()
 
                     let agenda = binding(.calendarViewAgenda)
@@ -326,6 +337,16 @@ struct AppCommands: Commands {
                     Button("Month View") { calendarActions.showMonth() }
                         .keyboardShortcut(month.key.keyEquivalent, modifiers: month.modifiers.eventModifiers)
                         .disabled(calendarActions.canShowMonth == false)
+
+                    let multiDay = binding(.calendarViewMultiDay)
+                    Button("Multi-Day View") { calendarActions.showMultiDay() }
+                        .keyboardShortcut(multiDay.key.keyEquivalent, modifiers: multiDay.modifiers.eventModifiers)
+                        .disabled(calendarActions.canShowMultiDay == false)
+
+                    let year = binding(.calendarViewYear)
+                    Button("Year View") { calendarActions.showYear() }
+                        .keyboardShortcut(year.key.keyEquivalent, modifiers: year.modifiers.eventModifiers)
+                        .disabled(calendarActions.canShowYear == false)
                 }
 
                 if let calendarEventEditorActions {

--- a/apps/apple/HotCrossBuns/App/HCBShortcuts.swift
+++ b/apps/apple/HotCrossBuns/App/HCBShortcuts.swift
@@ -40,10 +40,13 @@ enum HCBShortcutCommand: String, CaseIterable, Identifiable {
     case calendarGoToDate
     case calendarDuplicateEvent
     case calendarFocusSearch
+    case calendarShareAvailability
     case calendarViewAgenda
     case calendarViewDay
     case calendarViewWeek
     case calendarViewMonth
+    case calendarViewMultiDay
+    case calendarViewYear
     // Task inspector
     case taskSaveAndClose
     case taskQuickSave
@@ -80,10 +83,13 @@ enum HCBShortcutCommand: String, CaseIterable, Identifiable {
         case .calendarGoToDate: "Go to Date…"
         case .calendarDuplicateEvent: "Duplicate Event"
         case .calendarFocusSearch: "Focus Calendar Search"
+        case .calendarShareAvailability: "Share Availability…"
         case .calendarViewAgenda: "Switch to Agenda View"
         case .calendarViewDay: "Switch to Day View"
         case .calendarViewWeek: "Switch to Week View"
         case .calendarViewMonth: "Switch to Month View"
+        case .calendarViewMultiDay: "Switch to Multi-Day View"
+        case .calendarViewYear: "Switch to Year View"
         case .taskSaveAndClose: "Save and Close Task"
         case .taskQuickSave: "Save Task"
         case .taskDelete: "Delete Task"
@@ -105,7 +111,9 @@ enum HCBShortcutCommand: String, CaseIterable, Identifiable {
         case .calendarPrevious, .calendarToday,
              .calendarNext, .calendarJumpBack, .calendarJumpForward,
              .calendarGoToDate, .calendarDuplicateEvent, .calendarFocusSearch,
-             .calendarViewAgenda, .calendarViewDay, .calendarViewWeek, .calendarViewMonth:
+             .calendarShareAvailability, .calendarViewAgenda, .calendarViewDay,
+             .calendarViewWeek, .calendarViewMonth, .calendarViewMultiDay,
+             .calendarViewYear:
             .calendar
         case .taskSaveAndClose, .taskQuickSave, .taskDelete, .taskDuplicate:
             .taskInspector
@@ -140,10 +148,13 @@ enum HCBShortcutCommand: String, CaseIterable, Identifiable {
         case .calendarGoToDate: .init(key: .char("g"), modifiers: [.command, .shift])
         case .calendarDuplicateEvent: .init(key: .char("d"), modifiers: [.command])
         case .calendarFocusSearch: .init(key: .char("f"), modifiers: [.command])
+        case .calendarShareAvailability: .init(key: .char("a"), modifiers: [.command, .shift])
         case .calendarViewAgenda: .init(key: .char("1"), modifiers: [.command, .option])
         case .calendarViewDay: .init(key: .char("2"), modifiers: [.command, .option])
         case .calendarViewWeek: .init(key: .char("3"), modifiers: [.command, .option])
         case .calendarViewMonth: .init(key: .char("4"), modifiers: [.command, .option])
+        case .calendarViewMultiDay: .init(key: .char("5"), modifiers: [.command, .option])
+        case .calendarViewYear: .init(key: .char("6"), modifiers: [.command, .option])
         case .taskSaveAndClose: .init(key: .returnKey, modifiers: [.command, .shift])
         case .taskQuickSave: .init(key: .returnKey, modifiers: [.command])
         case .taskDelete: .init(key: .delete, modifiers: [.command])

--- a/apps/apple/HotCrossBuns/Features/Calendar/CalendarHomeView.swift
+++ b/apps/apple/HotCrossBuns/Features/Calendar/CalendarHomeView.swift
@@ -309,6 +309,18 @@ struct CalendarHomeView: View {
             Spacer(minLength: 0)
 
             Button {
+                openShareAvailability()
+            } label: {
+                Label("Share Availability", systemImage: "calendar.badge.clock")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .help("Share availability")
+            .accessibilityLabel("Share availability")
+            .disabled(canOpenShareAvailability == false)
+
+            Button {
                 router?.present(.quickCreate(Date(), allDay: true))
             } label: {
                 Label("New Event or Task", systemImage: "plus")
@@ -319,14 +331,7 @@ struct CalendarHomeView: View {
             .help("Open quick create")
             .accessibilityLabel("New event or task")
 
-            Picker("View", selection: modeBinding) {
-                ForEach(visibleCalendarModes, id: \.self) { m in
-                    Label(m.title, systemImage: m.systemImage).tag(m)
-                }
-            }
-            .pickerStyle(.menu)
-            .labelsHidden()
-            .fixedSize()
+            calendarViewModeControl
         }
         .hcbScaledPadding(.horizontal, 16)
         .hcbScaledPadding(.vertical, 10)
@@ -338,6 +343,32 @@ struct CalendarHomeView: View {
             }
         }
         .disabled(model.account == nil)
+    }
+
+    private var calendarViewModeControl: some View {
+        ViewThatFits(in: .horizontal) {
+            Picker("View", selection: modeBinding) {
+                calendarViewModePickerOptions
+            }
+            .pickerStyle(.segmented)
+            .fixedSize()
+
+            Picker("View", selection: modeBinding) {
+                calendarViewModePickerOptions
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .fixedSize()
+        }
+        .help("Choose calendar view")
+        .accessibilityLabel("Calendar view")
+    }
+
+    @ViewBuilder
+    private var calendarViewModePickerOptions: some View {
+        ForEach(visibleCalendarModes, id: \.self) { mode in
+            Label(mode.title, systemImage: mode.systemImage).tag(mode)
+        }
     }
 
     private var usesReadableCalendarChrome: Bool {
@@ -358,6 +389,10 @@ struct CalendarHomeView: View {
             return model.calendars.filter { $0.accessRole == "owner" || $0.accessRole == "writer" }
         }
         return writable
+    }
+
+    private var canOpenShareAvailability: Bool {
+        model.account != nil && writableCalendars.isEmpty == false
     }
 
     private var supportsAvailabilitySelection: Bool {
@@ -435,15 +470,21 @@ struct CalendarHomeView: View {
             focusSearch: {
                 NotificationCenter.default.post(name: .hcbFocusCalendarSearch, object: nil)
             },
+            shareAvailability: { openShareAvailability() },
             showAgenda: { selectMode(.agenda) },
             showDay: { selectMode(.day) },
             showWeek: { selectMode(.week) },
             showMonth: { selectMode(.month) },
+            showMultiDay: { selectMode(.multiDay) },
+            showYear: { selectMode(.year) },
             canNavigate: canNavigate,
+            canShareAvailability: canNavigate && canOpenShareAvailability,
             canShowAgenda: canNavigate && visibleCalendarModes.contains(.agenda),
             canShowDay: canNavigate && visibleCalendarModes.contains(.day),
             canShowWeek: canNavigate && visibleCalendarModes.contains(.week),
-            canShowMonth: canNavigate && visibleCalendarModes.contains(.month)
+            canShowMonth: canNavigate && visibleCalendarModes.contains(.month),
+            canShowMultiDay: canNavigate && visibleCalendarModes.contains(.multiDay),
+            canShowYear: canNavigate && visibleCalendarModes.contains(.year)
         )
     }
 
@@ -1215,6 +1256,8 @@ private struct ShareAvailabilityPanel: View {
                 Image(systemName: "xmark")
             }
             .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .help("Close Share Availability")
             .accessibilityLabel("Close Share Availability")
         }
     }

--- a/apps/apple/HotCrossBuns/Features/Status/ActionCenter.swift
+++ b/apps/apple/HotCrossBuns/Features/Status/ActionCenter.swift
@@ -411,6 +411,8 @@ struct ActionCenterDrawer: View {
                 Image(systemName: "xmark")
             }
             .buttonStyle(.borderless)
+            .keyboardShortcut(.cancelAction)
+            .help("Close notifications")
             .accessibilityLabel("Close notifications")
         }
         .hcbScaledPadding(.horizontal, 16)

--- a/apps/apple/HotCrossBunsMacTests/AccessibilityFoundationsTests.swift
+++ b/apps/apple/HotCrossBunsMacTests/AccessibilityFoundationsTests.swift
@@ -97,6 +97,34 @@ final class AccessibilityFoundationsTests: XCTestCase {
         XCTAssertFalse(actionCenter.contains("onTapGesture"))
     }
 
+    func testCalendarMacControlPolishHasDiscoverableCommandsAndCancelActions() throws {
+        let appCommands = try String(contentsOf: repoRoot.appending(path: "apps/apple/HotCrossBuns/App/AppCommands.swift"))
+        XCTAssertTrue(appCommands.contains("Button(\"Share Availability…\")"))
+        XCTAssertTrue(appCommands.contains("Button(\"Multi-Day View\")"))
+        XCTAssertTrue(appCommands.contains("Button(\"Year View\")"))
+        XCTAssertTrue(appCommands.contains(".calendarShareAvailability"))
+        XCTAssertTrue(appCommands.contains(".calendarViewMultiDay"))
+        XCTAssertTrue(appCommands.contains(".calendarViewYear"))
+        XCTAssertTrue(appCommands.contains("calendarActions.canShareAvailability == false"))
+        XCTAssertTrue(appCommands.contains("calendarActions.canShowMultiDay == false"))
+        XCTAssertTrue(appCommands.contains("calendarActions.canShowYear == false"))
+
+        let calendarHome = try String(contentsOf: repoRoot.appending(path: "apps/apple/HotCrossBuns/Features/Calendar/CalendarHomeView.swift"))
+        XCTAssertTrue(calendarHome.contains("ViewThatFits(in: .horizontal)"))
+        XCTAssertTrue(calendarHome.contains("calendarViewModeControl"))
+        XCTAssertTrue(calendarHome.contains("Label(\"Share Availability\", systemImage: \"calendar.badge.clock\")"))
+        XCTAssertTrue(calendarHome.contains(".disabled(canOpenShareAvailability == false)"))
+        XCTAssertTrue(calendarHome.contains("canShareAvailability: canNavigate && canOpenShareAvailability"))
+        XCTAssertTrue(calendarHome.contains("canShowMultiDay: canNavigate && visibleCalendarModes.contains(.multiDay)"))
+        XCTAssertTrue(calendarHome.contains("canShowYear: canNavigate && visibleCalendarModes.contains(.year)"))
+        XCTAssertTrue(calendarHome.contains(".keyboardShortcut(.cancelAction)"))
+        XCTAssertTrue(calendarHome.contains(".help(\"Close Share Availability\")"))
+
+        let actionCenter = try String(contentsOf: repoRoot.appending(path: "apps/apple/HotCrossBuns/Features/Status/ActionCenter.swift"))
+        XCTAssertTrue(actionCenter.contains(".keyboardShortcut(.cancelAction)"))
+        XCTAssertTrue(actionCenter.contains(".help(\"Close notifications\")"))
+    }
+
     private var repoRoot: URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/apps/apple/HotCrossBunsMacTests/AppSettingsMacSurfacesTests.swift
+++ b/apps/apple/HotCrossBunsMacTests/AppSettingsMacSurfacesTests.swift
@@ -349,6 +349,36 @@ final class AppSettingsMacSurfacesTests: XCTestCase {
         XCTAssertTrue(state.message.contains(proposed.displayLabel))
     }
 
+    @MainActor
+    func testCalendarPolishShortcutsExposeMacDefaultsWithoutConflicts() {
+        XCTAssertEqual(HCBShortcutCommand.calendarShareAvailability.group, .calendar)
+        XCTAssertEqual(HCBShortcutCommand.calendarShareAvailability.title, "Share Availability…")
+        XCTAssertEqual(HCBShortcutCommand.calendarShareAvailability.defaultBinding.displayLabel, "⇧⌘A")
+
+        XCTAssertEqual(HCBShortcutCommand.calendarViewMultiDay.group, .calendar)
+        XCTAssertEqual(HCBShortcutCommand.calendarViewMultiDay.title, "Switch to Multi-Day View")
+        XCTAssertEqual(HCBShortcutCommand.calendarViewMultiDay.defaultBinding.displayLabel, "⌥⌘5")
+
+        XCTAssertEqual(HCBShortcutCommand.calendarViewYear.group, .calendar)
+        XCTAssertEqual(HCBShortcutCommand.calendarViewYear.title, "Switch to Year View")
+        XCTAssertEqual(HCBShortcutCommand.calendarViewYear.defaultBinding.displayLabel, "⌥⌘6")
+
+        for command in [
+            HCBShortcutCommand.calendarShareAvailability,
+            .calendarViewMultiDay,
+            .calendarViewYear
+        ] {
+            XCTAssertTrue(
+                hcbConflictingCommands(
+                    proposed: command.defaultBinding,
+                    for: command,
+                    overrides: [:]
+                ).isEmpty,
+                "\(command.title) should not reuse an existing default shortcut."
+            )
+        }
+    }
+
     func testDisconnectImpactWarnsWithoutClaimingGoogleDeletion() {
         let summary = DisconnectImpactSummary(
             accountName: "Ada Lovelace",


### PR DESCRIPTION
## Summary
- add Calendar menu and shortcut parity for Share Availability, Multi-Day View, and Year View
- make the calendar toolbar view picker adaptive and add a visible Share Availability button
- add Escape/cancel polish for Share Availability and Action Center close buttons

## Validation
- git diff --check
- xcodebuild test -project apps/apple/HotCrossBuns.xcodeproj -scheme HotCrossBunsMac -destination 'platform=macOS,arch=arm64' -derivedDataPath build/apple/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -only-testing:HotCrossBunsMacTests/AccessibilityFoundationsTests -only-testing:HotCrossBunsMacTests/AppSettingsMacSurfacesTests
- xcodebuild -project apps/apple/HotCrossBuns.xcodeproj -scheme HotCrossBunsMac -destination 'platform=macOS,arch=arm64' -derivedDataPath build/apple/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test